### PR TITLE
Add support for Coturn and Twilio

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy a [Camus][camus] server on DigitalOcean using Terraform.
 This Terraform module creates a fully-configured Camus deployment on
 DigitalOcean. It creates a DigitalOcean droplet, configures networking and
 firewall rules, creates a DNS record for the desired domain, obtains an SSL
-certificate via Let's Encrypt, and installs the Camus server and Nginx on the
+certificate via Let's Encrypt, and installs Camus, Coturn, and Nginx on the
 droplet.
 
 ## Quickstart
@@ -76,20 +76,29 @@ records to propagate.)
 
 ### Inputs
 
-| Name                | Description                                                             | Type     | Default                                            | Required |
-| ------------------- | ----------------------------------------------------------------------- | -------- | -------------------------------------------------- | -------- |
-| do_token            | Your Digital Ocean [API token][do-token].                               | `string` |                                                    | Yes      |
-| domain              | The domain for your site.                                               | `string` |                                                    | Yes      |
-| certificate_email   | The email address for the SSL certificate.                              | `string` |                                                    | Yes      |
-| ssh_key_fingerprint | The fingerprint of the [SSH key][do-add-ssh-key] to add to the droplet. | `string` |                                                    | Yes      |
-| region              | The region where the droplet is deployed.                               | `string` | `"fra1"`                                           | No       |
-| droplet_size        | The size of the droplet.                                                | `string` | `"s-1vcpu-1gb"`                                    | No       |
-| droplet_image       | The OS image for the droplet.                                           | `string` | `"ubuntu-20-04-x64"`                               | No       |
-| droplet_backups     | Whether to enable backups on the droplet.                               | `bool`   | `false`                                            | No       |
-| droplet_monitoring  | Whether to enable monitoring on the droplet.                            | `bool`   | `false`                                            | No       |
-| droplet_ipv6        | Whether to enable IPv6 on the droplet.                                  | `bool`   | `false`                                            | No       |
-| project_environment | The deployment environment for the project.                             | `string` | `"Production"`                                     | No       |
-| acme_url            | The URL of the ACME server used to obtain an SSL certificate.           | `string` | `"https://acme-v02.api.letsencrypt.org/directory"` | No       |
+| Name                | Description                                                                  | Type     | Default                                            | Required |
+| ------------------- | ---------------------------------------------------------------------------- | -------- | -------------------------------------------------- | -------- |
+| do_token            | Your Digital Ocean [API token][do-token].                                    | `string` |                                                    | Yes      |
+| domain              | The domain for your site.                                                    | `string` |                                                    | Yes      |
+| certificate_email   | The email address for the SSL certificate.                                   | `string` |                                                    | Yes      |
+| ssh_key_fingerprint | The fingerprint of the [SSH key][do-add-ssh-key] to add to the droplet.      | `string` |                                                    | Yes      |
+| region              | The region where the droplet is deployed.                                    | `string` | `"fra1"`                                           | No       |
+| droplet_size        | The size of the droplet.                                                     | `string` | `"s-1vcpu-1gb"`                                    | No       |
+| droplet_image       | The OS image for the droplet.                                                | `string` | `"ubuntu-20-04-x64"`                               | No       |
+| droplet_backups     | Whether to enable backups on the droplet.                                    | `bool`   | `false`                                            | No       |
+| droplet_monitoring  | Whether to enable monitoring on the droplet.                                 | `bool`   | `false`                                            | No       |
+| droplet_ipv6        | Whether to enable IPv6 on the droplet.                                       | `bool`   | `false`                                            | No       |
+| project_environment | The deployment environment for the project.                                  | `string` | `"Production"`                                     | No       |
+| acme_url            | The URL of the ACME server used to obtain an SSL certificate.                | `string` | `"https://acme-v02.api.letsencrypt.org/directory"` | No       |
+| coturn_enabled      | Whether to install and configure a Coturn TURN server on the droplet.        | `bool`   | `true`                                             | No       |
+| coturn_listen_port  | The port to listen on for establishing new TURN connections.                 | `number` | `3478`                                             | No       |
+| coturn_min_port     | The beginning of the port range to use for TURN connections.                 | `number` | `10000`                                            | No       |
+| coturn_max_port     | The end of the port range to use for TURN connections.                       | `number` | `20000`                                            | No       |
+| stun_host           | The hostname or IP address of the STUN server to use for connecting clients. | `string` | `""`                                               | No       |
+| stun_port           | The port of the STUN server to use for connecting clients.                   | `number` | `19302`                                            | No       |
+| twilio_account_sid  | A Twilio account SID.                                                        | `string` | `""`                                               | No       |
+| twilio_auth_token   | A Twilio account [auth token][twilio-auth-token] or API key secret.          | `string` | `""`                                               | No       |
+| twilio_key_sid      | A Twilio API key SID.                                                        | `string` | `""`                                               | No       |
 
 ### Outputs
 
@@ -136,3 +145,4 @@ The following droplet images are supported:
 [configure-registrar]: https://www.digitalocean.com/community/tutorials/how-to-point-to-digitalocean-nameservers-from-common-domain-registrars
 [do-token]: https://www.digitalocean.com/docs/apis-clis/api/create-personal-access-token/
 [do-add-ssh-key]: https://www.digitalocean.com/docs/droplets/how-to/add-ssh-keys/to-account/
+[twilio-auth-token]: https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-How-to-Change-Them

--- a/cloud-config/centos.yaml
+++ b/cloud-config/centos.yaml
@@ -2,10 +2,12 @@ packages:
   - epel-release
 
 runcmd:
-  - yum -y install snapd nginx
+  - yum -y install snapd nginx coturn
   - setsebool -P httpd_can_network_connect 1
   - systemctl enable --now snapd.socket
   - snap wait system seed.loaded
   - snap install camus
   - systemctl enable nginx
   - systemctl start nginx
+  - systemctl enable coturn
+  - systemctl start coturn

--- a/cloud-config/centos.yaml
+++ b/cloud-config/centos.yaml
@@ -2,7 +2,7 @@ packages:
   - epel-release
 
 runcmd:
-  - yum -y install snapd nginx coturn
+  - yum -y install snapd nginx ${ coturn_enabled ? "coturn" : ""}
   - setsebool -P httpd_can_network_connect 1
   - systemctl enable --now snapd.socket
   - snap wait system seed.loaded
@@ -19,5 +19,5 @@ runcmd:
       twilio.key-sid=${twilio_key_sid}
   - systemctl enable nginx
   - systemctl start nginx
-  - systemctl enable coturn
-  - systemctl start coturn
+  ${ coturn_enabled ? "- systemctl enable coturn" : ""}
+  ${ coturn_enabled ? "- systemctl start coturn" : ""}

--- a/cloud-config/centos.yaml
+++ b/cloud-config/centos.yaml
@@ -7,6 +7,7 @@ runcmd:
   - systemctl enable --now snapd.socket
   - snap wait system seed.loaded
   - snap install camus
+  - snap set camus turn.host=${turn_host} turn.port=${turn_port} turn.static-auth-secret=${turn_static_auth_secret}
   - systemctl enable nginx
   - systemctl start nginx
   - systemctl enable coturn

--- a/cloud-config/centos.yaml
+++ b/cloud-config/centos.yaml
@@ -7,7 +7,16 @@ runcmd:
   - systemctl enable --now snapd.socket
   - snap wait system seed.loaded
   - snap install camus
-  - snap set camus turn.host=${turn_host} turn.port=${turn_port} turn.static-auth-secret=${turn_static_auth_secret}
+  - |
+    snap set camus \
+      stun.host=${stun_host} \
+      stun.port=${stun_port} \
+      turn.host=${turn_host} \
+      turn.port=${turn_port} \
+      turn.static-auth-secret=${turn_static_auth_secret} \
+      twilio.account-sid=${twilio_account_sid} \
+      twilio.auth-token=${twilio_auth_token} \
+      twilio.key-sid=${twilio_key_sid}
   - systemctl enable nginx
   - systemctl start nginx
   - systemctl enable coturn

--- a/cloud-config/common.yaml
+++ b/cloud-config/common.yaml
@@ -16,3 +16,8 @@ write_files:
     path: /etc/ssl/private/camus-key.pem
     owner: root:root
     permissions: '0600'
+  - content: ${base64encode(turn_conf)}
+    encoding: b64
+    path: /etc/turnserver.conf
+    owner: root:root
+    permissions: '0644'

--- a/cloud-config/debian.yaml
+++ b/cloud-config/debian.yaml
@@ -6,6 +6,16 @@ packages:
 runcmd:
   - snap install core camus
   - snap set camus turn.host=${turn_host} turn.port=${turn_port} turn.static-auth-secret=${turn_static_auth_secret}
+  - |
+    snap set camus \
+      stun.host=${stun_host} \
+      stun.port=${stun_port} \
+      turn.host=${turn_host} \
+      turn.port=${turn_port} \
+      turn.static-auth-secret=${turn_static_auth_secret} \
+      twilio.account-sid=${twilio_account_sid} \
+      twilio.auth-token=${twilio_auth_token} \
+      twilio.key-sid=${twilio_key_sid}
   - systemctl enable nginx
   - systemctl start nginx
   - systemctl enable coturn

--- a/cloud-config/debian.yaml
+++ b/cloud-config/debian.yaml
@@ -1,8 +1,11 @@
 packages:
   - snapd
   - nginx
+  - coturn
 
 runcmd:
   - snap install core camus
   - systemctl enable nginx
   - systemctl start nginx
+  - systemctl enable coturn
+  - systemctl start coturn

--- a/cloud-config/debian.yaml
+++ b/cloud-config/debian.yaml
@@ -1,11 +1,10 @@
 packages:
   - snapd
   - nginx
-  - coturn
+  ${ coturn_enabled ? "- coturn" : ""}
 
 runcmd:
   - snap install core camus
-  - snap set camus turn.host=${turn_host} turn.port=${turn_port} turn.static-auth-secret=${turn_static_auth_secret}
   - |
     snap set camus \
       stun.host=${stun_host} \
@@ -18,5 +17,5 @@ runcmd:
       twilio.key-sid=${twilio_key_sid}
   - systemctl enable nginx
   - systemctl start nginx
-  - systemctl enable coturn
-  - systemctl start coturn
+  ${ coturn_enabled ? "- systemctl enable coturn" : ""}
+  ${ coturn_enabled ? "- systemctl start coturn" : ""}

--- a/cloud-config/debian.yaml
+++ b/cloud-config/debian.yaml
@@ -5,6 +5,7 @@ packages:
 
 runcmd:
   - snap install core camus
+  - snap set camus turn.host=${turn_host} turn.port=${turn_port} turn.static-auth-secret=${turn_static_auth_secret}
   - systemctl enable nginx
   - systemctl start nginx
   - systemctl enable coturn

--- a/main.tf
+++ b/main.tf
@@ -57,12 +57,17 @@ resource "digitalocean_droplet" "main" {
       ssl_key = acme_certificate.certificate.private_key_pem
       turn_conf = templatefile("${path.module}/turnserver.conf", {
         realm = "turn.${var.domain}"
+        listen_port = var.coturn_listen_port
         min_port = var.coturn_min_port
         max_port = var.coturn_max_port
         static_auth_secret = random_password.coturn_static_auth_secret.result
       })
     }),
-    file("${path.module}/cloud-config/${local.distro}.yaml")
+    templatefile("${path.module}/cloud-config/${local.distro}.yaml", {
+      turn_host = "turn.${var.domain}"
+      turn_port = var.coturn_listen_port
+      turn_static_auth_secret = random_password.coturn_static_auth_secret.result
+    })
   ])
 
   tags = ["camus"]

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    random = {
+      source = "hashicorp/random"
+      version = "3.0.0"
+    }
     digitalocean = {
       source = "digitalocean/digitalocean"
       version = "2.2.0"
@@ -13,6 +17,10 @@ terraform {
 
 locals {
   distro = split("-", var.droplet_image)[0]
+}
+
+resource "random_password" "coturn_static_auth_secret" {
+  length = 32
 }
 
 provider "digitalocean" {
@@ -47,6 +55,12 @@ resource "digitalocean_droplet" "main" {
       nginx_conf = templatefile("${path.module}/nginx.conf", { domain = var.domain })
       ssl_cert = "${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"
       ssl_key = acme_certificate.certificate.private_key_pem
+      turn_conf = templatefile("${path.module}/turnserver.conf", {
+        realm = "turn.${var.domain}"
+        min_port = var.coturn_min_port
+        max_port = var.coturn_max_port
+        static_auth_secret = random_password.coturn_static_auth_secret.result
+      })
     }),
     file("${path.module}/cloud-config/${local.distro}.yaml")
   ])
@@ -87,6 +101,12 @@ resource "digitalocean_firewall" "main" {
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
 
+  inbound_rule {
+    protocol = "udp"
+    port_range = "${var.coturn_min_port}-${var.coturn_max_port}"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
   outbound_rule {
     protocol              = "tcp"
     port_range            = "1-65535"
@@ -111,6 +131,20 @@ resource "digitalocean_record" "main" {
   value = digitalocean_droplet.main.ipv4_address
 }
 
+resource "digitalocean_record" "turn" {
+  domain = digitalocean_domain.main.name
+  type = "CNAME"
+  name = "turn"
+  value = "${var.domain}."
+}
+
+resource "digitalocean_record" "stun" {
+  domain = digitalocean_domain.main.name
+  type = "CNAME"
+  name = "stun"
+  value = "${var.domain}."
+}
+
 provider "acme" {
   server_url = var.acme_url
 }
@@ -126,7 +160,8 @@ resource "acme_registration" "reg" {
 
 resource "acme_certificate" "certificate" {
   account_key_pem = acme_registration.reg.account_key_pem
-  common_name = var.domain
+  common_name = digitalocean_domain.main.id
+  subject_alternative_names = [digitalocean_record.turn.fqdn, digitalocean_record.stun.fqdn]
   key_type = "4096"
 
   dns_challenge {

--- a/turnserver.conf
+++ b/turnserver.conf
@@ -1,0 +1,16 @@
+realm=${realm}
+listening-ip=0.0.0.0
+tls-listening-port=3478
+min-port=${min_port}
+max-port=${max_port}
+fingerprint
+verbose
+use-auth-secret
+static-auth-secret=${static_auth_secret}
+
+# TLS configuration
+cert=/etc/ssl/certs/camus.pem;
+pkey=/etc/ssl/private/camus-key.pem;
+dh2066
+no-tlsv1
+no-tlsv1_1

--- a/turnserver.conf
+++ b/turnserver.conf
@@ -1,6 +1,6 @@
 realm=${realm}
 listening-ip=0.0.0.0
-tls-listening-port=3478
+tls-listening-port=${listen_port}
 min-port=${min_port}
 max-port=${max_port}
 fingerprint

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "acme_url" {
   description = "The URL of the ACME server used to obtain an SSL certificate."
 }
 
+variable "coturn_listen_port" {
+  type = number
+  default = 3478
+  description = "The port to listen on for establishing new TURN connections."
+}
+
 variable "coturn_min_port" {
   type = number
   default = 10000

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,33 @@ variable "coturn_max_port" {
   default = 20000
   description = "The end of the port range to use for TURN connections."
 }
+
+variable "stun_host" {
+  type = string
+  default = ""
+  description = "The hostname or IP address of the STUN server to use for connecting clients."
+}
+
+variable "stun_port" {
+  type = number
+  default = 19302
+  description = "The port of the STUN server to use for connecting clients."
+}
+
+variable "twilio_account_sid" {
+  type = string
+  default = ""
+  description = "A Twilio account SID."
+}
+
+variable "twilio_auth_token" {
+  type = string
+  default = ""
+  description = "A Twilio account auth token or API key secret."
+}
+
+variable "twilio_key_sid" {
+  type = string
+  default = ""
+  description = "A Twilio API key SID."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "acme_url" {
   description = "The URL of the ACME server used to obtain an SSL certificate."
 }
 
+variable "coturn_enabled" {
+  type = bool
+  default = true
+  description = "Whether to install and configure a Coturn TURN server on the droplet."
+}
+
 variable "coturn_listen_port" {
   type = number
   default = 3478

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,15 @@ variable "acme_url" {
   default = "https://acme-v02.api.letsencrypt.org/directory"
   description = "The URL of the ACME server used to obtain an SSL certificate."
 }
+
+variable "coturn_min_port" {
+  type = number
+  default = 10000
+  description = "The beginning of the port range to use for TURN connections."
+}
+
+variable "coturn_max_port" {
+  type = number
+  default = 20000
+  description = "The end of the port range to use for TURN connections."
+}


### PR DESCRIPTION
This PR creates infrastructure and configuration to support running a [Coturn](https://github.com/coturn/coturn) TURN server, including:
- [x] Configure firewall rules
- [x] Create DNS records for `turn` and `stun` subdomains
- [x] Add the `turn` and `stun` subdomains to the SSL cert
- [x] Install and configure Coturn on the server
- [x] Configure Camus to use the Coturn server (Depends on https://github.com/mrgnr/camus/pull/18)

[Twilio](https://www.twilio.com/stun-turn) can also now be used for TURN & STUN by providing Twilio credentials via `twilio_account_sid`, `twilio_auth_token`, and `twilio_key_sid`.